### PR TITLE
Use an alias for the Integer class in Randomize.php

### DIFF
--- a/src/Randomize.php
+++ b/src/Randomize.php
@@ -2,7 +2,7 @@
 
 namespace HiFolks\RandoPhp;
 
-use HiFolks\RandoPhp\Models\Integer;
+use HiFolks\RandoPhp\Models\Integer as ModelInt;
 use HiFolks\RandoPhp\Models\Boolean;
 use HiFolks\RandoPhp\Models\Byte;
 use HiFolks\RandoPhp\Models\Sequence;
@@ -23,11 +23,11 @@ class Randomize
     /**
      * Generates random numbers
      *
-     * @return Integer
+     * @return ModelInt
      */
     public static function integer()
     {
-        return new Integer();
+        return new ModelInt();
     }
 
     /**


### PR DESCRIPTION
I altered the import of the Integer import to use an alias instead. This resolved the issue with some versions of PHPstorm and phpstan lvl 2 of displaying errors on the max function. This should fix issue #10 