### PR TITLE
Change assertEquals to assertSame.

### DIFF
--- a/tests/DrawSampleTest.php
+++ b/tests/DrawSampleTest.php
@@ -16,10 +16,10 @@ class DrawSampleTest extends TestCase
         $count=5;
         $sample = Draw::sample($array)->count($count)->extract();
         $this->assertIsArray($sample);
-        $this->assertEquals($count, count($sample));
+        $this->assertSame($count, count($sample));
         $sampleKeys = Draw::sample($array)->count($count)->extractKeys();
         $this->assertIsArray($sampleKeys);
-        $this->assertEquals($count, count($sampleKeys));
+        $this->assertSame($count, count($sampleKeys));
     }
     /** @test */
     public function random_extract_duplicates()
@@ -28,7 +28,7 @@ class DrawSampleTest extends TestCase
         $count = 5;
         $sample = Draw::sample($array)->allowDuplicates()->count($count)->extract();
         $this->assertIsArray($sample);
-        $this->assertEquals($count, count($sample));
+        $this->assertSame($count, count($sample));
     }
 
     /** @test */
@@ -38,7 +38,7 @@ class DrawSampleTest extends TestCase
         $count = 5;
         $sampleKeys = Draw::sample($array)->count($count)->extractKeys();
         $this->assertIsArray($sampleKeys, "Check extract key is array");
-        $this->assertEquals($count, count($sampleKeys), "Check extract count is correct");
+        $this->assertSame($count, count($sampleKeys), "Check extract count is correct");
     }
 
     /** @test */
@@ -69,7 +69,7 @@ class DrawSampleTest extends TestCase
         $count=5;
         $sample = Draw::sample($array)->count($count)->preserveKeys()->extract();
         $this->assertIsArray($sample);
-        $this->assertEquals($count, count($sample), "Check extract count is correct");
+        $this->assertSame($count, count($sample), "Check extract count is correct");
     }
 
 }

--- a/tests/RandomByteTest.php
+++ b/tests/RandomByteTest.php
@@ -15,7 +15,7 @@ class RandomByteTest extends TestCase
 
         foreach (range(1,32) as $len) {
             $byte = Randomize::byte()->length($len)->generate();
-            $this->assertEquals($len*2, strlen($byte), "Check length ". $len);
+            $this->assertSame($len*2, strlen($byte), "Check length ". $len);
         }
         $catch = false;
         try {
@@ -24,7 +24,7 @@ class RandomByteTest extends TestCase
             $catch = true;
             $this->assertStringContainsString("Length must be greater", $e->getMessage(), "Message Error test");
         }
-        $this->assertEquals(true, $catch, "Exception catch");
+        $this->assertSame(true, $catch, "Exception catch");
 
 
     }

--- a/tests/RandomDateTimeTest.php
+++ b/tests/RandomDateTimeTest.php
@@ -31,7 +31,7 @@ class RandomDateTimeTest extends TestCase
     public function random_datetime_range_format()
     {
         $month = Randomize::datetime()->range('01-10-2020', '30-10-2020')->format("m")->generate();
-        $this->assertEquals("10", $month );
+        $this->assertSame("10", $month );
     }
 
 }

--- a/tests/RandomIntegerTest.php
+++ b/tests/RandomIntegerTest.php
@@ -48,7 +48,7 @@ class RandomIntegerTest extends TestCase
             $catch = true;
             $this->assertStringContainsString("Minimum", $e->getMessage(), "Message Error test");
         }
-        $this->assertEquals(true, $catch, "Exception catch");
+        $this->assertSame(true, $catch, "Exception catch");
     }
 
 

--- a/tests/RandomSequenceTest.php
+++ b/tests/RandomSequenceTest.php
@@ -20,7 +20,7 @@ class RandomSequenceTest extends TestCase
     {
         $array = Randomize::sequence()->count(7)->generate();
         $this->assertIsArray($array, "Check is array");
-        $this->assertEquals(7, count($array), "Check length array generated");
+        $this->assertSame(7, count($array), "Check length array generated");
 
     }
 
@@ -32,7 +32,7 @@ class RandomSequenceTest extends TestCase
         $max=6;
         $array = Randomize::sequence()->min($min)->max($max)->count($count)->generate();
         $this->assertIsArray($array, "Check is array");
-        $this->assertEquals($count, count($array), "Check length array generated");
+        $this->assertSame($count, count($array), "Check length array generated");
         foreach ($array as $item) {
             $this->assertGreaterThanOrEqual(1, $item, "Greater than " . $min);
             $this->assertLessThanOrEqual(6, $item, "Less than " . $min);
@@ -41,7 +41,7 @@ class RandomSequenceTest extends TestCase
         // the same as before, forcing integer items
         $array = Randomize::sequence()->min($min)->max($max)->count($count)->generate();
         $this->assertIsArray($array, "Check is array");
-        $this->assertEquals($count, count($array), "Check length array generated");
+        $this->assertSame($count, count($array), "Check length array generated");
         foreach ($array as $item) {
             $this->assertGreaterThanOrEqual(1, $item, "Greater than " . $min);
             $this->assertLessThanOrEqual(6, $item, "Less than " . $min);
@@ -49,7 +49,7 @@ class RandomSequenceTest extends TestCase
 
         $array = Randomize::sequence()->min($min)->max($max)->count($count)->allowDuplicates()->generate();
         $this->assertIsArray($array, "Check is array");
-        $this->assertEquals($count, count($array), "Check length array generated");
+        $this->assertSame($count, count($array), "Check length array generated");
         foreach ($array as $item) {
             $this->assertGreaterThanOrEqual(1, $item, "Greater than " . $min);
             $this->assertLessThanOrEqual(6, $item, "Less than " . $min);
@@ -67,13 +67,13 @@ class RandomSequenceTest extends TestCase
         $max=90;
         $array = Randomize::sequence()->integer()->min($min)->max($max)->noDuplicates()->count($count)->generate();
         $this->assertIsArray($array, "Check is array");
-        $this->assertEquals($count, count($array), "Check length array generated");
+        $this->assertSame($count, count($array), "Check length array generated");
         foreach ($array as $item) {
             $this->assertGreaterThanOrEqual(1, $item, "Greater than " . $min);
             $this->assertLessThanOrEqual(90, $item, "Less than " . $min);
         }
 
-        $this->assertEquals($count, count(array_unique($array)), "Check uniqueness");
+        $this->assertSame($count, count(array_unique($array)), "Check uniqueness");
 
 
 


### PR DESCRIPTION
AssertSame reports an error if the two elements do not share type and value.
For example: this code $this->assertEquals(3, true); give uns true :-////
Please use assertSame, not assertEquals