### PR TITLE
Load models with magic methods to simplify the loading process

### DIFF
--- a/src/Exceptions/ModelNotFoundException.php
+++ b/src/Exceptions/ModelNotFoundException.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace HiFolks\RandoPhp\Exceptions;
+
+
+class ModelNotFoundException extends \Exception
+{
+
+}

--- a/src/Randomize.php
+++ b/src/Randomize.php
@@ -2,9 +2,10 @@
 
 namespace HiFolks\RandoPhp;
 
+use HiFolks\RandoPhp\Exceptions\ModelNotFoundException;
+use HiFolks\RandoPhp\Models\Boolean;
 use HiFolks\RandoPhp\Models\Char;
-use HiFolks\RandoPhp\Models\Integer as ModelInt;
-use HiFolks\RandoPhp\Models\Boolean as ModelBool;
+use HiFolks\RandoPhp\Models\Integer;
 use HiFolks\RandoPhp\Models\DateTime;
 use HiFolks\RandoPhp\Models\Byte;
 use HiFolks\RandoPhp\Models\FloatModel;
@@ -15,77 +16,38 @@ class Randomize
 {
 
     /**
-     * Generates random boolean
+     * Registered models with format: 'methodToLoadModel' => ClassName
+     */
+    private static $models = [
+        'boolean' => Boolean::class,
+        'integer' => Integer::class,
+        'float' => FloatModel::class,
+        'byte' => Byte::class,
+        'sequence' => Sequence::class,
+        'datetime' => DateTime::class,
+        'char' => Char::class,
+        'latlong' => LatLong::class,
+    ];
+
+    /**
+     * Return the model registered in $models property
      *
-     * @return ModelBool
+     * @param $name
+     * @param $arguments
+     * @return mixed
+     * @throws ModelNotFoundException
      */
-    public static function boolean()
+    public static function __callStatic($name, $arguments)
     {
-        return new ModelBool();
-    }
+        if(in_array($name, array_keys(self::$models))) {
 
-    /**
-     * Generates random numbers
-     *
-     * @return ModelInt
-     */
-    public static function integer()
-    {
-        return new ModelInt();
-    }
+            if(count($arguments))
+                return new self::$models[$name]($arguments);
 
-    /**
-     * Generates random floating point numbers
-     *
-     * @return FloatModel
-     */
-    public static function float()
-    {
-        return new FloatModel();
-    }
+            return new self::$models[$name];
 
-    /**
-     * Generates random byte (32 bit), something in hexadecimal format [0-f][0-f]
-     *
-     * @return Byte
-     */
-    public static function byte()
-    {
-        return new Byte();
-    }
+        }
 
-    /**
-     * @return Sequence
-     */
-    public static function sequence()
-    {
-        return new Sequence();
-    }
-
-    /**
-     * Generate random date (datetime), you can pass format option default Y-m-d H:i:s
-     * @return Datetime()
-     */
-    public static function datetime()
-    {
-        return new Datetime();
-    }
-
-    /**
-     * @return Char
-     */
-    public static function char()
-    {
-        return new Char();
-    }
-
-    /**
-     * Generates random latitude / longitude coordinates in both array and object form.
-     *
-     * @return LatLong
-     */
-    public static function latlong(): LatLong
-    {
-        return new LatLong();
+        throw new ModelNotFoundException('Model not found');
     }
 }

--- a/tests/LoadModelsWithMagicFunctionsTest.php
+++ b/tests/LoadModelsWithMagicFunctionsTest.php
@@ -1,0 +1,76 @@
+<?php
+
+
+namespace HiFolks\RandoPhp\Tests;
+
+use HiFolks\RandoPhp\Exceptions\ModelNotFoundException;
+use HiFolks\RandoPhp\Models;
+use HiFolks\RandoPhp\Models\LatLong;
+use HiFolks\RandoPhp\Randomize;
+use PHPUnit\Framework\TestCase;
+
+class LoadModelsWithMagicFunctionsTest extends TestCase
+{
+    /** @test */
+    public function load_boolean_test()
+    {
+        $model = Randomize::boolean();
+        $this->assertInstanceOf(Models\Boolean::class, $model);
+    }
+
+    /** @test */
+    public function load_integer_test()
+    {
+        $model = Randomize::integer();
+        $this->assertInstanceOf(Models\Integer::class, $model);
+    }
+
+    /** @test */
+    public function load_float_test()
+    {
+        $model = Randomize::float();
+        $this->assertInstanceOf(Models\FloatModel::class, $model);
+    }
+
+    /** @test */
+    public function load_byte_test()
+    {
+        $model = Randomize::byte();
+        $this->assertInstanceOf(Models\Byte::class, $model);
+    }
+
+    /** @test */
+    public function load_sequence_test()
+    {
+        $model = Randomize::sequence();
+        $this->assertInstanceOf(Models\Sequence::class, $model);
+    }
+
+    /** @test */
+    public function load_datetime_test()
+    {
+        $model = Randomize::datetime();
+        $this->assertInstanceOf(Models\DateTime::class, $model);
+    }
+
+    /** @test */
+    public function load_char_test()
+    {
+        $model = Randomize::char();
+        $this->assertInstanceOf(Models\Char::class, $model);
+    }
+
+    /** @test */
+    public function load_latlong_test()
+    {
+        $model = Randomize::latlong();
+        $this->assertInstanceOf(Models\LatLong::class, $model);
+    }
+
+    /** @test */
+    public function model_not_found_exception_test()
+    {
+        $this->expectException(ModelNotFoundException::class);
+        $model = Randomize::nonExistingModel();
+    }
+}


### PR DESCRIPTION
This pull request change completilly the way that the Randomize class load the differents model by registering them in a static property and using the magic method __callStatic.

The idea of this pull request is simplify the way that you can add new models, change them or delete them only by adding a "signature" in the $modules property and the class name.

`
public static $models = [
    'signature' => ModelClassName
];
`

In other way, if a signature is not registered, the Randomize class will through a ModelNotFoundException.

I know that this not was registered as an issue, but I think that could be useful.

Thanks! :)